### PR TITLE
Allows utm source to be set on request to book appointment

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Set a filter to determine who should be notified when booking an appointment.
 
 Set an attribute which will tell the API to use the given start date time string as the start time of the new appointment.
 
+- `source(source: string)`
+
+Set an attribute which will tell the API to use the given source string as the source when creating an appointment (ie. the UTM source)
+
 - `via(invitation: number)`
 
 Set an attribute which will tell the API to use the given invitation identifier when creating an appointment.
@@ -113,7 +117,7 @@ class Appointments {
   async book(attributes) {
     const {
       address, city, country, email, firstName, invitation, language, lastName,
-      location, notes, phone, question, service, start, user, value,
+      location, notes, phone, question, service, source, start, user, value,
     } = attributes;
 
     const answer = (new Answer())
@@ -134,6 +138,7 @@ class Appointments {
       .by(user)
       .for(service)
       .starting(start)
+      .source(source)
       .via(invitation)
       .with(attendee)
       .notify({

--- a/src/resources/appointment.test.ts
+++ b/src/resources/appointment.test.ts
@@ -148,6 +148,7 @@ it('can book an appointment with all available parameters', async () => {
       .by(4)
       .via(5)
       .starting(start)
+      .source('test source')
       .with(
         attendee
           .named('Jane', 'Doe')
@@ -225,6 +226,7 @@ it('can book an appointment with all available parameters', async () => {
       },
       meta: {
         notify: notification,
+        source: 'test source',
       },
     });
 

--- a/src/resources/appointment.test.ts
+++ b/src/resources/appointment.test.ts
@@ -46,6 +46,14 @@ it('can set the service property using a multiple numbers', async () => {
   });
 });
 
+it('can set the source property', async () => {
+  const resource = new Appointment(mockAxios);
+
+  expect(resource.source('test source')).toHaveProperty('filters', {
+      source: 'test source',
+  });
+});
+
 it('can set the notifications property', async () => {
   const resource = new Appointment(mockAxios);
   const notifications: AppointmentNotificationParameters = {

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -211,7 +211,7 @@ export default class Appointment extends Conditional implements AppointmentResou
       };
     }
 
-    if(this.filters.source) {
+    if (this.filters.source) {
       params = {
         ...params,
         meta: {

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -10,6 +10,7 @@ export interface AppointmentFilter {
   matchers?: AppointmentMatcherParameters;
   notifications?: AppointmentNotificationParameters;
   services?: number | number[];
+  source?: string;
   start?: string;
   user?: number;
 }
@@ -46,6 +47,7 @@ export interface AppointmentParameters {
       client?: boolean;
       user?: boolean;
     };
+    source?: string;
   };
 }
 
@@ -65,6 +67,8 @@ export interface AppointmentResource extends Resource, ConditionalResource {
   notify(notifications: AppointmentNotificationParameters): this;
 
   starting(start: string): this;
+
+  source(source: string): this;
 
   via(invitation: number): this;
 
@@ -140,6 +144,12 @@ export default class Appointment extends Conditional implements AppointmentResou
     return this;
   }
 
+  public source(source: string): this {
+    this.filters.source = source;
+
+    return this;
+  }
+
   public via(invitation: number): this {
     this.filters.invitation = invitation;
 
@@ -199,6 +209,16 @@ export default class Appointment extends Conditional implements AppointmentResou
           notify: this.filters.notifications,
         },
       };
+    }
+
+    if(this.filters.source) {
+      params = {
+        ...params,
+        meta: {
+          ...params.meta,
+          source: this.filters.source,
+        },
+      }
     }
 
     return params;


### PR DESCRIPTION
## Description

Allows the source of an appointment booking to be set. 

## Motivation and context

It can be useful to know where an appointment originated from. One use case is for storing the UTM (Urchin Tracking Module) source.

## How has this been tested?

Added more tests to your current files.

## Screenshots (if appropriate)

N/A

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.