### PR TITLE
Allows setting remaining UTM parameters on request to book appointment

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Set a relationship which will tell the API to use the given user identifier when
 
 Cancel an appointment for a specific attendee matching the given appointment and attendee identifiers.
 
+- `campaign(campaign: string)`
+
+Set an attribute which will tell the API to use the given string as the campaign UTM parameter when creating an appointment.
+
+- `content(content: string)`
+
+Set an attribute which will tell the API to use the given string as the content UTM parameter when creating an appointment.
+
 - `for(services: number | numbers[])`
 
 Set a relationship which will tell the API to use the given service identifier when creating an appointment.
@@ -83,6 +91,10 @@ Find an appointment matching the pre-set matching parameters.
 - `matching(matchers: AppointmentMatcherParameters)`
 
 Set a filter to use in order to find an existing appointment.
+
+- `medium(medium: string)`
+
+Set an attribute which will tell the API to use the given string as the medium UTM parameter when creating an appointment.
 
 - `notify(notifications: AppointmentNotificationParameters)`
 
@@ -98,7 +110,11 @@ Set an attribute which will tell the API to use the given start date time string
 
 - `source(source: string)`
 
-Set an attribute which will tell the API to use the given source string as the source when creating an appointment (ie. the UTM source)
+Set an attribute which will tell the API to use the given string as the source UTM parameter when creating an appointment.
+
+- `term(term: string)`
+
+Set an attribute which will tell the API to use the given string as the term UTM parameter when creating an appointment.
 
 - `via(invitation: number)`
 
@@ -120,8 +136,8 @@ class Appointments {
 
   async book(attributes) {
     const {
-      address, city, country, email, firstName, invitation, language, lastName,
-      location, notes, phone, question, service, source, start, user, value,
+      address, campaign, city, content, country, email, firstName, invitation, language, lastName,
+      location, medium, notes, phone, question, service, source, start, term, user, value,
     } = attributes;
 
     const answer = (new Answer())
@@ -142,7 +158,11 @@ class Appointments {
       .by(user)
       .for(service)
       .starting(start)
+      .campaign(campaign)
+      .content(content)
+      .medium(medium)
       .source(source)
+      .term(term)
       .via(invitation)
       .with(attendee)
       .notify({

--- a/src/resources/appointment.test.ts
+++ b/src/resources/appointment.test.ts
@@ -46,11 +46,43 @@ it('can set the service property using a multiple numbers', async () => {
   });
 });
 
+it('can set the campaign property', async () => {
+  const resource = new Appointment(mockAxios);
+
+  expect(resource.campaign('test campaign')).toHaveProperty('utm', {
+    campaign: 'test campaign',
+  });
+});
+
+it('can set the content property', async () => {
+  const resource = new Appointment(mockAxios);
+
+  expect(resource.content('test content')).toHaveProperty('utm', {
+    content: 'test content',
+  });
+});
+
+it('can set the medium property', async () => {
+  const resource = new Appointment(mockAxios);
+
+  expect(resource.medium('test medium')).toHaveProperty('utm', {
+    medium: 'test medium',
+  });
+});
+
 it('can set the source property', async () => {
   const resource = new Appointment(mockAxios);
 
   expect(resource.source('test source')).toHaveProperty('utm', {
-      source: 'test source',
+    source: 'test source',
+  });
+});
+
+it('can set the term property', async () => {
+  const resource = new Appointment(mockAxios);
+
+  expect(resource.term('test term')).toHaveProperty('utm', {
+    term: 'test term',
   });
 });
 

--- a/src/resources/appointment.test.ts
+++ b/src/resources/appointment.test.ts
@@ -49,7 +49,7 @@ it('can set the service property using a multiple numbers', async () => {
 it('can set the source property', async () => {
   const resource = new Appointment(mockAxios);
 
-  expect(resource.source('test source')).toHaveProperty('filters', {
+  expect(resource.source('test source')).toHaveProperty('utm', {
       source: 'test source',
   });
 });
@@ -226,7 +226,9 @@ it('can book an appointment with all available parameters', async () => {
       },
       meta: {
         notify: notification,
-        source: 'test source',
+        utm: {
+            source: 'test source',
+        },
       },
     });
 

--- a/src/resources/appointment.test.ts
+++ b/src/resources/appointment.test.ts
@@ -180,7 +180,11 @@ it('can book an appointment with all available parameters', async () => {
       .by(4)
       .via(5)
       .starting(start)
+      .campaign('test campaign')
+      .content('test content')
+      .medium('test medium')
       .source('test source')
+      .term('test term')
       .with(
         attendee
           .named('Jane', 'Doe')
@@ -259,7 +263,11 @@ it('can book an appointment with all available parameters', async () => {
       meta: {
         notify: notification,
         utm: {
-            source: 'test source',
+          campaign: 'test campaign',
+          content: 'test content',
+          medium: 'test medium',
+          source: 'test source',
+          term: 'test term',
         },
       },
     });

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -239,19 +239,23 @@ export default class Appointment extends Conditional implements AppointmentResou
       };
     }
 
-    if (this.utm.source) {
+    if (this.hasUtm()) {
       params = {
         ...params,
         meta: {
           ...params.meta,
           utm: {
-            source: this.utm.source,
+            ...this.utm.source && {source: this.utm.source},
           },
         },
       };
     }
 
     return params;
+  }
+
+  protected hasUtm(): boolean {
+    return !!(this.utm.source)
   }
 
   protected rescheduleParams(): RescheduleParameters | object {

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -10,9 +10,12 @@ export interface AppointmentFilter {
   matchers?: AppointmentMatcherParameters;
   notifications?: AppointmentNotificationParameters;
   services?: number | number[];
-  source?: string;
   start?: string;
   user?: number;
+}
+
+export interface Utm {
+  source?: string;
 }
 
 export interface AppointmentMatcherParameters {
@@ -102,6 +105,7 @@ export default class Appointment extends Conditional implements AppointmentResou
   protected client: AxiosInstance;
   protected filters: AppointmentFilter;
   protected relationships: AppointmentRelationship;
+  protected utm: Utm;
 
   constructor(client: AxiosInstance) {
     super();
@@ -111,6 +115,7 @@ export default class Appointment extends Conditional implements AppointmentResou
     this.relationships = {
       attendees: [],
     };
+    this.utm = {};
   }
 
   public at(location: number): this {
@@ -168,7 +173,7 @@ export default class Appointment extends Conditional implements AppointmentResou
   }
 
   public source(source: string): this {
-    this.filters.source = source;
+    this.utm.source = source;
 
     return this;
   }
@@ -234,13 +239,13 @@ export default class Appointment extends Conditional implements AppointmentResou
       };
     }
 
-    if (this.filters.source) {
+    if (this.utm.source) {
       params = {
         ...params,
         meta: {
           ...params.meta,
           utm: {
-            source: this.filters.source,
+            source: this.utm.source,
           },
         },
       };

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -14,7 +14,7 @@ export interface AppointmentFilter {
   user?: number;
 }
 
-export interface Utm {
+export interface UtmParameters {
   campaign?: string;
   content?: string;
   medium?: string;
@@ -121,7 +121,7 @@ export default class Appointment extends Conditional implements AppointmentResou
   protected client: AxiosInstance;
   protected filters: AppointmentFilter;
   protected relationships: AppointmentRelationship;
-  protected utm: Utm;
+  protected utm: UtmParameters;
 
   constructor(client: AxiosInstance) {
     super();

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -86,17 +86,11 @@ export interface AppointmentResource extends Resource, ConditionalResource {
 
   by(user: number): this;
 
-  campaign(campaign: string): this;
-
   cancel(appointment: number, attendee: number): Promise<any>;
-
-  content(content: string): this;
 
   for(services: number | number[]): this;
 
   matching(matchers: AppointmentMatcherParameters): this;
-
-  medium(medium: string): this;
 
   notify(notifications: AppointmentNotificationParameters): this;
 
@@ -104,20 +98,28 @@ export interface AppointmentResource extends Resource, ConditionalResource {
 
   starting(start: string): this;
 
-  source(source: string): this;
-
-  term(term: string): this;
-
   via(invitation: number): this;
 
   with(attendees: AttendeeModel | AttendeeModel[]): this;
+}
+
+export interface Utm {
+  campaign(campaign: string): this;
+
+  content(content: string): this;
+
+  medium(medium: string): this;
+
+  source(source: string): this;
+
+  term(term: string): this;
 }
 
 export interface AppointmentRelationship {
   attendees: AttendeeModel[] | [];
 }
 
-export default class Appointment extends Conditional implements AppointmentResource {
+export default class Appointment extends Conditional implements AppointmentResource, Utm {
   protected client: AxiosInstance;
   protected filters: AppointmentFilter;
   protected relationships: AppointmentRelationship;

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -47,7 +47,9 @@ export interface AppointmentParameters {
       client?: boolean;
       user?: boolean;
     };
-    source?: string;
+    utm?: {
+      source?: string;
+    };
   };
 }
 
@@ -237,9 +239,11 @@ export default class Appointment extends Conditional implements AppointmentResou
         ...params,
         meta: {
           ...params.meta,
-          source: this.filters.source,
+          utm: {
+            source: this.filters.source,
+          },
         },
-      }
+      };
     }
 
     return params;

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -55,7 +55,11 @@ export interface AppointmentParameters {
       user?: boolean;
     };
     utm?: {
+      campaign?: string;
+      content?: string;
       source?: string;
+      medium?: string;
+      term?: string;
     };
   };
 }
@@ -281,7 +285,11 @@ export default class Appointment extends Conditional implements AppointmentResou
         meta: {
           ...params.meta,
           utm: {
+            ...this.utm.campaign && {campaign: this.utm.campaign},
+            ...this.utm.content && {content: this.utm.content},
+            ...this.utm.medium && {medium: this.utm.medium},
             ...this.utm.source && {source: this.utm.source},
+            ...this.utm.term && {term: this.utm.term},
           },
         },
       };
@@ -291,7 +299,11 @@ export default class Appointment extends Conditional implements AppointmentResou
   }
 
   protected hasUtm(): boolean {
-    return !!(this.utm.source)
+    return !!(this.utm.campaign)
+      || !!(this.utm.content)
+      || !!(this.utm.medium)
+      || !!(this.utm.source)
+      || !!(this.utm.term);
   }
 
   protected rescheduleParams(): RescheduleParameters | object {

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -15,7 +15,11 @@ export interface AppointmentFilter {
 }
 
 export interface Utm {
+  campaign?: string;
+  content?: string;
+  medium?: string;
   source?: string;
+  term?: string;
 }
 
 export interface AppointmentMatcherParameters {
@@ -78,11 +82,17 @@ export interface AppointmentResource extends Resource, ConditionalResource {
 
   by(user: number): this;
 
+  campaign(campaign: string): this;
+
   cancel(appointment: number, attendee: number): Promise<any>;
+
+  content(content: string): this;
 
   for(services: number | number[]): this;
 
   matching(matchers: AppointmentMatcherParameters): this;
+
+  medium(medium: string): this;
 
   notify(notifications: AppointmentNotificationParameters): this;
 
@@ -91,6 +101,8 @@ export interface AppointmentResource extends Resource, ConditionalResource {
   starting(start: string): this;
 
   source(source: string): this;
+
+  term(term: string): this;
 
   via(invitation: number): this;
 
@@ -134,8 +146,20 @@ export default class Appointment extends Conditional implements AppointmentResou
     return this;
   }
 
+  public campaign(campaign: string): this {
+    this.utm.campaign = campaign;
+
+    return this;
+  }
+
   public async cancel(appointment: number, attendee: number): Promise<any> {
     return await this.client.delete(`appointments/${appointment}/${attendee}`, this.params());
+  }
+
+  public content(content: string): this {
+    this.utm.content = content;
+
+    return this;
   }
 
   public for(services: number | number[]): this {
@@ -152,6 +176,12 @@ export default class Appointment extends Conditional implements AppointmentResou
 
   public matching(matchers: AppointmentMatcherParameters): this {
     this.filters.matchers = matchers;
+
+    return this;
+  }
+
+  public medium(medium: string): this {
+    this.utm.medium = medium;
 
     return this;
   }
@@ -174,6 +204,12 @@ export default class Appointment extends Conditional implements AppointmentResou
 
   public source(source: string): this {
     this.utm.source = source;
+
+    return this;
+  }
+
+  public term(term: string): this {
+    this.utm.term = term;
 
     return this;
   }


### PR DESCRIPTION
## Description

Allows the campaign, content, medium, and term UTM (Urchin Tracking Module) parameters to be set on the request to book an appointment.

## Motivation and context

It can be useful to know where an appointment originated from. Having support for the remaining UTM parameters allows the full context of where an appointment originated from to be recorded.

## How has this been tested?

Adds tests to your existing files.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.