### PR TITLE
Add resource to services locations and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,6 +786,10 @@ Set a filter which will tell the API to return users that support the given meet
 
 Set the limit which you want returned.
 
+- `through(resource: string)`
+
+Set a filter which will tell the API which resource the request comes from. Currently, only 'client_view' is supported.
+
 ##### Example
 
 ```javascript
@@ -796,13 +800,14 @@ class Users {
     this.api = new OpenApi();
   }
 
-  async get({ limit, location, method, page, services, sortable }) {
+  async get({ limit, location, method, page, resource, services, sortable }) {
     return await this.api
       .users()
       .assigned()
       .at(location)
       .performing(services)
       .supporting(method)
+      .through(resource)
       .on(page)
       .sortBy(sortable)
       .take(limit)

--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ Set a filter which will tell the API to return locations that are supported by t
 
 Set the limit which you want returned.
 
+- `through(resource: string)`
+
+Set a filter which will tell the API which resource the request comes from. Currently, only 'client_view' is supported.
+
 - `virtual()`
 
 Set a filter which will tell the API to return only virtual locations. _(not publicly available yet)_
@@ -440,7 +444,7 @@ class Locations {
     return await this.api.details(identifier);
   }
 
-  async get({ page, limit, method, services, sortable, user }) {
+  async get({ page, limit, method, resource, services, sortable, user }) {
     return await this.api
       .locations()
       .assigned()
@@ -450,6 +454,7 @@ class Locations {
       .physical()
       .supporting(method)
       .sortBy(sortable)
+      .through(resource)
       .on(page)
       .take(limit)
       .get();

--- a/README.md
+++ b/README.md
@@ -619,6 +619,10 @@ Set a filter which will tell the API to return services that are supported by th
 
 Set the limit which you want returned.
 
+- `through(resource: string)`
+
+Set a filter which will tell the API which resource the request comes from. Currently, only 'client_view' is supported.
+
 ##### Example
 
 ```javascript
@@ -629,7 +633,7 @@ class Services {
     this.api = new OpenApi();
   }
 
-  async get({ category, limit, location, method, page, sortable, user }) {
+  async get({ category, limit, location, method, page, resource, sortable, user }) {
     return await this.api
       .services()
       .assigned()
@@ -638,6 +642,7 @@ class Services {
       .in(category)
       .invitable()
       .supporting(method)
+      .through(resource)
       .on(page)
       .sortBy(sortable)
       .take(limit)

--- a/src/resources/location.test.ts
+++ b/src/resources/location.test.ts
@@ -90,6 +90,14 @@ it('will set meeting method filter using a number', async () => {
   });
 });
 
+it('will set resource filter', async () => {
+  const resource = new Location(mockAxios);
+
+  expect(resource.through('client_view')).toHaveProperty('filters', {
+    resource: 'client_view',
+  });
+});
+
 it('will set the physical locations only filter', async () => {
   const resource = new Location(mockAxios);
 
@@ -152,6 +160,7 @@ it('can string all filterable options together', async () => {
       .physical()
       .preferred()
       .supporting(MeetingMethods.PHONE_CALL)
+      .through('client_view')
       .located({ city: 'Fake City', country: 'FC', region: 'FR' })
       .take(5)
       .on(1),
@@ -165,6 +174,7 @@ it('can string all filterable options together', async () => {
     method: MeetingMethods.PHONE_CALL,
     preferred: 1,
     region: 'FR',
+    resource: 'client_view',
     services: [1, 2],
     user: 1,
     virtual: 0,
@@ -194,6 +204,7 @@ it('can get locations with additional parameters', async () => {
     .physical()
     .preferred()
     .supporting(MeetingMethods.PHONE_CALL)
+    .through('client_view')
     .located({ city: 'Fake City', country: 'FC', region: 'FR' })
     .sortBy('created')
     .take(5)
@@ -211,6 +222,7 @@ it('can get locations with additional parameters', async () => {
       'filter[preferred]': 1,
       'filter[province]': 'FR',
       'filter[service]': [1, 2],
+      'filter[resource]': 'client_view',
       'filter[user]': 1,
       'filter[virtual]': 0,
       limit: 5,

--- a/src/resources/location.ts
+++ b/src/resources/location.ts
@@ -21,6 +21,7 @@ export interface LocationFilter {
   preferred?: number;
   method?: number;
   services?: number | number[] | string | string[];
+  resource?: string;
   user?: number | string;
   virtual?: number;
 }
@@ -34,6 +35,7 @@ export interface LocationParameters {
   preferred?: number;
   province?: string;
   service?: number | number[] | string | string[];
+  resource?: string;
   user?: number | string;
   virtual?: number;
 }
@@ -58,6 +60,8 @@ export interface LocationResource extends Pageable, ConditionalResource {
   suggest(query: string): Promise<any>;
 
   supporting(method: number): this;
+
+  through(resource: string): this;
 
   virtual(): this;
 }
@@ -192,6 +196,12 @@ export default class Location extends Conditional implements LocationResource {
     return this;
   }
 
+  public through(resource: string): this {
+    this.filters.resource = resource;
+
+    return this;
+  }
+
   public virtual(): this {
     this.filters.virtual = 1;
 
@@ -227,6 +237,10 @@ export default class Location extends Conditional implements LocationResource {
 
     if (typeof this.filters.region !== 'undefined') {
       params.province = this.filters.region;
+    }
+
+    if (typeof this.filters.resource !== 'undefined') {
+      params.resource = this.filters.resource;
     }
 
     if (typeof this.filters.services !== 'undefined') {

--- a/src/resources/service.test.ts
+++ b/src/resources/service.test.ts
@@ -99,6 +99,14 @@ it('will set the individual filter', async () => {
   });
 });
 
+it('will set the resource filter', async () => {
+  const resource = new Service(mockAxios);
+
+  expect(resource.through('client_view')).toHaveProperty('filters', {
+    resource: 'client_view',
+  });
+});
+
 it('will set the page we are on', async () => {
   const resource = new Service(mockAxios);
 
@@ -138,6 +146,7 @@ it('can string all filterable options together', async () => {
       .individual()
       .preferred()
       .supporting(MeetingMethods.PHONE_CALL)
+      .through('client_view')
       .sortBy('created')
       .take(5)
       .on(1),
@@ -151,6 +160,7 @@ it('can string all filterable options together', async () => {
     location: 1,
     method: MeetingMethods.PHONE_CALL,
     preferred: 1,
+    resource: 'client_view',
     user: 2,
   });
   expected.toHaveProperty('sortable', 'created');
@@ -179,6 +189,7 @@ it('can get services with additional parameters', async () => {
     .individual()
     .preferred()
     .supporting(MeetingMethods.PHONE_CALL)
+    .through('client_view')
     .sortBy('created')
     .take(5)
     .on(1)
@@ -194,6 +205,7 @@ it('can get services with additional parameters', async () => {
       'filter[invite_only]': 1,
       'filter[location]': 1,
       'filter[preferred]': 1,
+      'filter[resource]': 'client_view',
       'filter[user]': 2,
       limit: 5,
       page: 1,

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -12,6 +12,7 @@ export interface ServiceFilter {
   location?: number | string;
   method?: number;
   preferred?: number;
+  resource?: string;
   user?: number | string;
 }
 
@@ -23,6 +24,7 @@ export interface ServiceParameters {
   invite_only?: number;
   location?: number | string;
   preferred?: number;
+  resource?: string;
   user?: number | string;
 }
 
@@ -44,6 +46,8 @@ export interface ServiceResource extends Pageable, ConditionalResource {
   preferred(): this;
 
   supporting(method: number): this;
+
+  through(resource: string): this;
 }
 
 export default class Service extends Conditional implements ServiceResource {
@@ -158,6 +162,12 @@ export default class Service extends Conditional implements ServiceResource {
     return this;
   }
 
+  public through(resource: string): this {
+    this.filters.resource = resource;
+
+    return this;
+  }
+
   protected params(): ServiceParameters {
     const params: ServiceParameters = {};
 
@@ -187,6 +197,10 @@ export default class Service extends Conditional implements ServiceResource {
 
     if (typeof this.filters.preferred !== 'undefined') {
       params.preferred = this.filters.preferred;
+    }
+
+    if (typeof this.filters.resource !== 'undefined') {
+      params.resource = this.filters.resource;
     }
 
     if (typeof this.filters.user !== 'undefined') {

--- a/src/resources/user.test.ts
+++ b/src/resources/user.test.ts
@@ -97,6 +97,14 @@ it('will set service filter using an array of strings', async () => {
   });
 });
 
+it('will set resource filter', async () => {
+  const resource = new User(mockAxios);
+
+  expect(resource.through('client_view')).toHaveProperty('filters', {
+    resource: 'client_view',
+  });
+});
+
 it('will set the limit given', async () => {
   const resource = new User(mockAxios);
 
@@ -118,6 +126,7 @@ it('can string all filterable options together', async () => {
       .at(1)
       .performing([1, 2])
       .supporting(MeetingMethods.PHONE_CALL)
+      .through('client_view')
       .sortBy('created')
       .find(1)
       .take(5)
@@ -128,6 +137,7 @@ it('can string all filterable options together', async () => {
     assigned: true,
     location: 1,
     method: MeetingMethods.PHONE_CALL,
+    resource: 'client_view',
     services: [1, 2],
     user: 1,
   });
@@ -153,6 +163,7 @@ it('can get users with additional parameters', async () => {
     .at(1)
     .performing([1, 2])
     .supporting(MeetingMethods.PHONE_CALL)
+    .through('client_view')
     .find(1)
     .sortBy('created')
     .take(5)
@@ -166,6 +177,7 @@ it('can get users with additional parameters', async () => {
       'filter[client_view_meeting_method]': MeetingMethods.PHONE_CALL,
       'filter[location]': 1,
       'filter[meeting_method]': MeetingMethods.PHONE_CALL,
+      'filter[resource]': 'client_view',
       'filter[service]': [1, 2],
       'filter[user]': 1,
       limit: 5,

--- a/src/resources/user.ts
+++ b/src/resources/user.ts
@@ -8,6 +8,7 @@ export interface UserFilter {
   assigned?: boolean;
   services?: number | number[] | string | string[];
   location?: number | string;
+  resource?: string;
   user?: number | string;
   method?: number;
 }
@@ -17,6 +18,7 @@ export interface UserParameters {
   client_view_meeting_method?: number;
   service?: number | number[] | string | string[];
   location?: number | string;
+  resource?: string;
   user?: number | string;
   meeting_method?: number;
 }
@@ -31,6 +33,8 @@ export interface UserResource extends Pageable, ConditionalResource {
   performing(services: number | number[] | string | string[]): this;
 
   supporting(method: number): this;
+
+  through(resource: string): this;
 }
 
 export default class User extends Conditional implements UserResource {
@@ -115,6 +119,12 @@ export default class User extends Conditional implements UserResource {
     return this;
   }
 
+  public through(resource: string): this {
+    this.filters.resource = resource;
+
+    return this;
+  }
+
   public take(limit: number): this {
     this.limit = limit;
 
@@ -139,6 +149,10 @@ export default class User extends Conditional implements UserResource {
     if (typeof this.filters.method !== 'undefined') {
       params.client_view_meeting_method = this.filters.method;
       params.meeting_method = this.filters.method;
+    }
+
+    if (typeof this.filters.resource !== 'undefined') {
+      params.resource = this.filters.resource;
     }
 
     if (typeof this.filters.user !== 'undefined') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds an optional filter that signifies the resource that the request comes from.

## Motivation and context

This change is necessary to differentiate between requests that come from the client view and other resources when checking service meeting methods.

## How has this been tested?

Expanded on existing and added new tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](https://travis-ci.org) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
