### PR TITLE
Adds support for arbitrary metadata

### DIFF
--- a/src/resources/appointment.test.ts
+++ b/src/resources/appointment.test.ts
@@ -186,6 +186,14 @@ it('can set an identifier for who we are acting as when booking the appointment'
   });
 });
 
+it('can set arbitrary metadata', async () => {
+  const resource = new Appointment(mockAxios);
+
+  expect(resource.metadata({ test: 'data' })).toHaveProperty('meta', {
+    test: 'data',
+  });
+});
+
 it('can book an appointment with the minimum required parameters', async () => {
   const resource = new Appointment(mockAxios);
   const start = '2018-01-01 12:00:00';
@@ -244,6 +252,7 @@ it('can book an appointment with all available parameters', async () => {
       .by(4)
       .via(5)
       .starting(start)
+      .metadata({ test: 'data' })
       .method(PHONE_CALL)
       .in('America/Toronto')
       .supporting('fr')
@@ -339,6 +348,7 @@ it('can book an appointment with all available parameters', async () => {
       meta: {
         booker: 10,
         notify: notification,
+        test: 'data',
         utm: {
           campaign: 'test campaign',
           content: 'test content',
@@ -613,6 +623,7 @@ it('can reschedule an appointment with all available parameters', async () => {
     await resource
       .starting(start)
       .in('America/Toronto')
+      .metadata({ test: 'data' })
       .notify(notification)
       .reschedule(1, 'code');
 
@@ -627,6 +638,7 @@ it('can reschedule an appointment with all available parameters', async () => {
       },
       meta: {
         notify: notification,
+        test: 'data',
       },
     });
   }

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -37,6 +37,21 @@ export interface AppointmentNotificationParameters {
   user?: boolean;
 }
 
+export interface AppointmentMeta {
+  booker?: number;
+  notify?: {
+    client?: boolean;
+    user?: boolean;
+  };
+  utm?: {
+    campaign?: string;
+    content?: string;
+    source?: string;
+    medium?: string;
+    term?: string;
+  };
+}
+
 export interface AppointmentParameters {
   data: {
     attributes?: {
@@ -58,20 +73,7 @@ export interface AppointmentParameters {
     };
     type: string;
   };
-  meta?: {
-    booker?: number;
-    notify?: {
-      client?: boolean;
-      user?: boolean;
-    };
-    utm?: {
-      campaign?: string;
-      content?: string;
-      source?: string;
-      medium?: string;
-      term?: string;
-    };
-  };
+  meta?: AppointmentMeta;
 }
 
 export interface RescheduleParameters {
@@ -164,10 +166,6 @@ export interface Utm {
 
 export interface AppointmentRelationship {
   attendees: AttendeeModel[] | [];
-}
-
-export interface AppointmentMeta {
-  booker?: number;
 }
 
 export default class Appointment extends Conditional implements AppointmentResource, Utm {

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -37,15 +37,6 @@ export interface AppointmentNotificationParameters {
   user?: boolean;
 }
 
-export interface AppointmentMeta {
-  booker?: number;
-  notify?: {
-    client?: boolean;
-    user?: boolean;
-  };
-  utm?: UtmParameters;
-}
-
 export interface AppointmentParameters {
   data: {
     attributes?: {
@@ -68,6 +59,16 @@ export interface AppointmentParameters {
     type: string;
   };
   meta?: AppointmentMeta;
+}
+
+export interface AppointmentMeta {
+  booker?: number;
+  notify?: {
+    client?: boolean;
+    user?: boolean;
+  };
+  utm?: UtmParameters;
+  [key: string]: unknown;
 }
 
 export interface RescheduleParameters {
@@ -128,6 +129,8 @@ export interface AppointmentResource extends Resource, ConditionalResource {
   in(timezone: string): this;
 
   matching(matchers: AppointmentMatcherParameters): this;
+
+  metadata(data: AppointmentMeta): this;
 
   method(method: number): this;
 
@@ -262,6 +265,15 @@ export default class Appointment extends Conditional implements AppointmentResou
 
   public medium(medium: string): this {
     this.utm.medium = medium;
+
+    return this;
+  }
+
+  public metadata(data: AppointmentMeta): this {
+    this.meta = {
+      ...this.meta,
+      ...data,
+    }
 
     return this;
   }
@@ -436,12 +448,12 @@ export default class Appointment extends Conditional implements AppointmentResou
       };
     }
 
-    if (this.meta.booker) {
+    if (Object.keys(this.meta).length !== 0) {
       params = {
         ...params,
         meta: {
           ...params.meta,
-          booker: this.meta.booker,
+          ...this.meta,
         }
       }
     }
@@ -471,6 +483,16 @@ export default class Appointment extends Conditional implements AppointmentResou
           notify: this.filters.notifications,
         },
       };
+    }
+
+    if (Object.keys(this.meta).length !== 0) {
+      params = {
+        ...params,
+        meta: {
+          ...params.meta,
+          ...this.meta,
+        }
+      }
     }
 
     return params;

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -43,13 +43,7 @@ export interface AppointmentMeta {
     client?: boolean;
     user?: boolean;
   };
-  utm?: {
-    campaign?: string;
-    content?: string;
-    source?: string;
-    medium?: string;
-    term?: string;
-  };
+  utm?: UtmParameters;
 }
 
 export interface AppointmentParameters {

--- a/src/resources/time-slot.test.ts
+++ b/src/resources/time-slot.test.ts
@@ -107,6 +107,14 @@ it('will set a visibility filter', async () => {
   });
 });
 
+it('can set arbitrary metadata', async () => {
+  const resource = new TimeSlot(mockAxios);
+
+  expect(resource.metadata({ test: 'data' })).toHaveProperty('meta', {
+    test: 'data',
+  });
+});
+
 it('can string all filterable options together', async () => {
   const resource = new TimeSlot(mockAxios);
 
@@ -151,6 +159,7 @@ it('can get time slots for no particular user', async () => {
     .in(timezone)
     .excluding(1)
     .visibility(Visibilities.ALL)
+    .metadata({ test: 'data' })
     .get();
 
   expect(mockAxios.get).toHaveBeenCalledTimes(1);
@@ -159,6 +168,7 @@ it('can get time slots for no particular user', async () => {
       end: '2018-01-31',
       exclusion: 1,
       location_id: 1,
+      meta: { test: 'data' },
       service_id: [1, 2],
       start: '2018-01-01',
       supported_locales: ['fr', 'es'],
@@ -182,12 +192,14 @@ it('can get time slots for a specified user', async () => {
     .by(1)
     .in(timezone)
     .visibility(Visibilities.ALL)
+    .metadata({ test: 'data' })
     .get();
 
   expect(mockAxios.get).toHaveBeenCalledTimes(1);
   expect(mockAxios.get).toHaveBeenCalledWith('times', {
     params: {
       end: '2018-01-31',
+      meta: { test: 'data' },
       location_id: 1,
       service_id: [1, 2],
       staff_id: 1,

--- a/src/resources/time-slot.ts
+++ b/src/resources/time-slot.ts
@@ -23,12 +23,17 @@ export interface TimeSlotParameters {
   exclusion?: number;
   location_id?: number;
   meeting_method?: number;
+  meta?: TimeSlotMeta;
   service_id?: number | number[];
   staff_id?: number;
   start?: string;
   supported_locales?: string[];
   timezone?: string;
   visibility?: number;
+}
+
+export interface TimeSlotMeta {
+  [key: string]: unknown;
 }
 
 export interface TimeSlotResource extends Resource, ConditionalResource {
@@ -46,6 +51,8 @@ export interface TimeSlotResource extends Resource, ConditionalResource {
 
   in(timezone: string): this;
 
+  metadata(data: TimeSlotMeta): this;
+
   method(method: number): this;
 
   supporting(locales: string[]): this;
@@ -56,12 +63,14 @@ export interface TimeSlotResource extends Resource, ConditionalResource {
 export default class TimeSlot extends Conditional implements TimeSlotResource {
   protected client: AxiosInstance;
   protected filters: TimeSlotFilter;
+  protected meta: TimeSlotMeta;
 
   constructor(client: AxiosInstance) {
     super();
 
     this.client = client;
     this.filters = {};
+    this.meta = {};
   }
 
   public at(location: number): this {
@@ -105,6 +114,7 @@ export default class TimeSlot extends Conditional implements TimeSlotResource {
     const params: TimeSlotParameters = {
       end: this.filters.end,
       location_id: this.filters.location,
+      meta: this.meta,
       service_id: this.filters.services,
       start: this.filters.start,
     };
@@ -142,6 +152,15 @@ export default class TimeSlot extends Conditional implements TimeSlotResource {
 
   public in(timezone: string): this {
     this.filters.timezone = timezone;
+
+    return this;
+  }
+
+  public metadata(data: TimeSlotMeta): this {
+    this.meta = {
+      ...this.meta,
+      ...data,
+    }
 
     return this;
   }


### PR DESCRIPTION
## Description

Adds support for setting arbitrary metadata when working with Appointment and TimeSlot.
No documentation added, since Coconut only does something with the documented metadata fields, which already have specific methods available for each field.

## Motivation and context

Allows setting metadata for internal purposes.

## How has this been tested?

Adds tests and modifies existing tests to achieve coverage. 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
