### PR TITLE
Add user category filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Set a relationship which will tell the API to use the given attendee model(s) wh
 
 Set an attribute which will tell the API to allow invite only location, service and user to be used when creating an appointment.
 
+- `withinUserCategory(userCategory: number)`
+
+Set a relationship which will tell the API to use the given user category identifier when creating an appointment.
+
 - `withoutMeetingLink(skipMeetingLinkGeneration?: boolean)`
 
 Set an attribute which will tell the API to skip the meeting link generation when creating an appointment.
@@ -201,7 +205,7 @@ class Appointments {
   async book(attributes) {
     const {
       address, campaign, city, content, country, email, firstName, invitation, language, lastName,
-      location, locale, medium, notes, phone, question, service, source, start, term, timezone, user, users, value,
+      location, locale, medium, notes, phone, question, service, source, start, term, timezone, user, userCategory, users, value,
     } = attributes;
 
     const answer = (new Answer())
@@ -234,6 +238,7 @@ class Appointments {
       .with(attendee)
       .through(Origins.MODERN_CLIENT_VIEW)
       .withInviteOnly()
+      .withinUserCategory(userCategory)
       .withoutMeetingLink()
       .notify(Notifications.ALL)
       .book();
@@ -456,6 +461,10 @@ Set a filter which will tell the API to return only virtual locations.
 
 Set an attribute which will tell the API to allow locations that are invite only or have invite only services or users assigned to them.
 
+- `withinUserCategory(userCategory: number | string)`
+
+Set a filter which will tell the API to return locations where users assigned to it are within the category matching the provided identifier.
+
 ##### Example
 
 ```javascript
@@ -470,7 +479,7 @@ class Locations {
     return await this.api.details(identifier);
   }
 
-  async get({ page, limit, method, resource, services, sortable, user }) {
+  async get({ page, limit, method, resource, services, sortable, user, userCategory }) {
     return await this.api
       .locations()
       .assigned()
@@ -480,6 +489,7 @@ class Locations {
       .physical()
       .supporting(method)
       .withInviteOnly()
+      .withinUserCategory(userCategory)
       .sortBy(sortable)
       .through(resource)
       .on(page)
@@ -663,6 +673,10 @@ Set a filter which will tell the API which resource the request comes from. Curr
 
 Set an attribute which will tell the API to allow services that are invite only or have invite only locations or users assigned to them.
 
+- `withinUserCategory(userCategory: number | string)`
+
+Set a filter which will tell the API to return services that are provided by user within the category matching the provided identifier.
+
 ##### Example
 
 ```javascript
@@ -673,7 +687,7 @@ class Services {
     this.api = new OpenApi();
   }
 
-  async get({ category, limit, location, method, page, region, resource, sortable, user }) {
+  async get({ category, limit, location, method, page, region, resource, sortable, user, userCategory }) {
     return await this.api
       .services()
       .assigned()
@@ -685,6 +699,7 @@ class Services {
       .supporting(method)
       .through(resource)
       .withInviteOnly()
+      .withinUserCategory(userCategory)
       .on(page)
       .sortBy(sortable)
       .take(limit)
@@ -765,6 +780,10 @@ Set a filter which will tell the API whether to return time slots belonging to a
 
 Set an attribute which will tell the API to return time slots belonging to public and invite only resources.
 
+- `withinUserCategory(userCategory: number)`
+
+Set a filter which will tell the API to return time slots that are specifically for users within the category matching the provided identifier.
+
 ##### Example
 
 ```javascript
@@ -775,7 +794,7 @@ class TimeSlots {
     this.api = new OpenApi();
   }
 
-  async get({ appointment, end, location, service, start, user, users }) {
+  async get({ appointment, end, location, service, start, user, userCategory, users }) {
     return await this.api
       .slots()
       .at(location)
@@ -788,6 +807,7 @@ class TimeSlots {
       .supporting(['en', 'fr', 'es'])
       .visibility(Visibilities.ALL)
       .withInviteOnly()
+      .withinUserCategory(userCategory)
       .get()
   }
 }

--- a/src/resources/appointment.test.ts
+++ b/src/resources/appointment.test.ts
@@ -56,6 +56,14 @@ it('can set the user property', async () => {
   });
 });
 
+it('can set the user category property', async () => {
+  const resource = new Appointment(mockAxios);
+
+  expect(resource.withinUserCategory(1)).toHaveProperty('filters', {
+    user_category: 1,
+  });
+});
+
 it('can set the users property using a number', async () => {
   const resource = new Appointment(mockAxios);
 
@@ -296,6 +304,7 @@ it('can book an appointment with all available parameters', async () => {
       .term('test term')
       .actingAs(10)
       .withInviteOnly()
+      .withinUserCategory(1)
       .withoutMeetingLink()
       .with(
         attendee
@@ -334,6 +343,7 @@ it('can book an appointment with all available parameters', async () => {
           location_id: 1,
           meeting_method: PHONE_CALL,
           service_id: [2, 3],
+          staff_category_id: 1,
           staff_id: 4,
           start,
           supported_locale: 'fr',

--- a/src/resources/appointment.ts
+++ b/src/resources/appointment.ts
@@ -19,6 +19,7 @@ export interface AppointmentFilter {
   through?: number;
   timezone?: string;
   user?: number;
+  user_category?: number;
   users?: number | number[];
 }
 
@@ -51,6 +52,7 @@ export interface AppointmentParameters {
       location_id: number | undefined;
       meeting_method?: number;
       service_id: number | number[] | undefined;
+      staff_category_id?: number;
       staff_id: number | null;
       start: string | undefined;
       supported_locale: string | null;
@@ -159,6 +161,8 @@ export interface AppointmentResource extends Resource, ConditionalResource {
   with(attendees: AttendeeModel | AttendeeModel[]): this;
 
   withInviteOnly(inviteOnlyResources?: boolean): this;
+
+  withinUserCategory(userCategory: number): this;
 
   withoutMeetingLink(skipMeetingLinkGeneration?: boolean): this;
 }
@@ -356,6 +360,12 @@ export default class Appointment extends Conditional implements AppointmentResou
 
     return this;
   }
+  
+  public withinUserCategory(userCategory: number): this {
+    this.filters.user_category = userCategory;
+
+    return this;
+  }
 
   public withoutMeetingLink(skipMeetingLinkGeneration: boolean = true): this {
     this.filters.skip_meeting_link_generation = skipMeetingLinkGeneration;
@@ -427,6 +437,10 @@ export default class Appointment extends Conditional implements AppointmentResou
 
       if (this.filters.user) {
         params.data.attributes.staff_id = this.filters.user;
+      }
+
+      if (this.filters.user_category) {
+        params.data.attributes.staff_category_id = this.filters.user_category;
       }
 
       if (this.filters.users) {

--- a/src/resources/location.test.ts
+++ b/src/resources/location.test.ts
@@ -36,6 +36,22 @@ it('will set user filter using a string', async () => {
   });
 });
 
+it('will set user category filter using a number', async () => {
+  const resource = new Location(mockAxios);
+
+  expect(resource.withinUserCategory(1)).toHaveProperty('filters', {
+    user_category: 1,
+  });
+});
+
+it('will set user category filter using a string', async () => {
+  const resource = new Location(mockAxios);
+
+  expect(resource.withinUserCategory('identifier')).toHaveProperty('filters', {
+    user_category: 'identifier',
+  });
+});
+
 it('will set the invite only filter', async () => {
   const resource = new Location(mockAxios);
 
@@ -179,6 +195,7 @@ it('can string all filterable options together', async () => {
       .through('client_view')
       .located({ city: 'Fake City', country: 'FC', region: 'FR' })
       .withInviteOnly()
+      .withinUserCategory(1)
       .take(5)
       .on(1),
   );
@@ -195,6 +212,7 @@ it('can string all filterable options together', async () => {
     resource: 'client_view',
     services: [1, 2],
     user: 1,
+    user_category: 1,
     virtual: 0,
   });
   expected.toHaveProperty('sortable', 'created');
@@ -225,6 +243,7 @@ it('can get locations with additional parameters', async () => {
     .through('client_view')
     .located({ city: 'Fake City', country: 'FC', region: 'FR' })
     .withInviteOnly()
+    .withinUserCategory(1)
     .sortBy('created')
     .take(5)
     .on(1)
@@ -244,6 +263,7 @@ it('can get locations with additional parameters', async () => {
       'filter[service]': [1, 2],
       'filter[resource]': 'client_view',
       'filter[user]': 1,
+      'filter[user_category]': 1,
       'filter[virtual]': 0,
       limit: 5,
       page: 1,

--- a/src/resources/location.ts
+++ b/src/resources/location.ts
@@ -24,6 +24,7 @@ export interface LocationFilter {
   services?: number | number[] | string | string[];
   resource?: string;
   user?: number | string;
+  user_category?: number | string;
   virtual?: number;
 }
 
@@ -39,6 +40,7 @@ export interface LocationParameters {
   service?: number | number[] | string | string[];
   resource?: string;
   user?: number | string;
+  user_category?: number | string;
   virtual?: number;
 }
 
@@ -68,6 +70,8 @@ export interface LocationResource extends Pageable, ConditionalResource {
   virtual(): this;
 
   withInviteOnly(inviteOnlyResources?: boolean): this;
+
+  withinUserCategory(userCategory: number | string): this;
 }
 
 export default class Location extends Conditional implements LocationResource {
@@ -218,6 +222,12 @@ export default class Location extends Conditional implements LocationResource {
     return this;
   }
 
+  public withinUserCategory(userCategory: number | string): this {
+    this.filters.user_category = userCategory;
+
+    return this;
+  }
+
   protected params(): LocationParameters {
     const params: LocationParameters = {};
 
@@ -263,6 +273,10 @@ export default class Location extends Conditional implements LocationResource {
 
     if (typeof this.filters.user !== 'undefined') {
       params.user = this.filters.user;
+    }
+
+    if (typeof this.filters.user_category !== 'undefined') {
+      params.user_category = this.filters.user_category;
     }
 
     if (typeof this.filters.virtual !== 'undefined') {

--- a/src/resources/service.test.ts
+++ b/src/resources/service.test.ts
@@ -82,6 +82,22 @@ it('will set user filter using a string', async () => {
   });
 });
 
+it('will set user category filter using a number', async () => {
+  const resource = new Service(mockAxios);
+
+  expect(resource.withinUserCategory(1)).toHaveProperty('filters', {
+    user_category: 1,
+  });
+});
+
+it('will set user category filter using a string', async () => {
+  const resource = new Service(mockAxios);
+
+  expect(resource.withinUserCategory('identifier')).toHaveProperty('filters', {
+    user_category: 'identifier',
+  });
+});
+
 it('will set category filter using a number', async () => {
   const resource = new Service(mockAxios);
 
@@ -172,6 +188,7 @@ it('can string all filterable options together', async () => {
       .supporting(MeetingMethods.PHONE_CALL)
       .through('client_view')
       .withInviteOnly()
+      .withinUserCategory(1)
       .sortBy('created')
       .take(5)
       .on(1),
@@ -189,6 +206,7 @@ it('can string all filterable options together', async () => {
     region: 'SK',
     resource: 'client_view',
     user: 2,
+    user_category: 1,
   });
   expected.toHaveProperty('sortable', 'created');
   expected.toHaveProperty('limit', 5);
@@ -219,6 +237,7 @@ it('can get services with additional parameters', async () => {
     .supporting(MeetingMethods.PHONE_CALL)
     .through('client_view')
     .withInviteOnly()
+    .withinUserCategory(1)
     .sortBy('created')
     .take(5)
     .on(1)
@@ -238,6 +257,7 @@ it('can get services with additional parameters', async () => {
       'filter[province]': 'SK',
       'filter[resource]': 'client_view',
       'filter[user]': 2,
+      'filter[user_category]': 1,
       limit: 5,
       page: 1,
       sort: 'created',

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -23,6 +23,7 @@ export interface ServiceFilter {
   preferred?: number;
   resource?: string;
   user?: number | string;
+  user_category?: number | string;
 }
 
 export interface ServiceParameters {
@@ -37,6 +38,7 @@ export interface ServiceParameters {
   province?: string;
   resource?: string;
   user?: number | string;
+  user_category?: number | string;
 }
 
 export interface ServiceResource extends Pageable, ConditionalResource {
@@ -63,6 +65,8 @@ export interface ServiceResource extends Pageable, ConditionalResource {
   through(resource: string): this;
 
   withInviteOnly(inviteOnlyResources?: boolean): this;
+
+  withinUserCategory(userCategory: number | string): this;
 }
 
 export default class Service extends Conditional implements ServiceResource {
@@ -199,6 +203,12 @@ export default class Service extends Conditional implements ServiceResource {
     return this;
   }
 
+  public withinUserCategory(userCategory: number | string): this {
+    this.filters.user_category = userCategory;
+
+    return this;
+  }
+
   protected params(): ServiceParameters {
     const params: ServiceParameters = {};
 
@@ -244,6 +254,10 @@ export default class Service extends Conditional implements ServiceResource {
 
     if (typeof this.filters.user !== 'undefined') {
       params.user = this.filters.user;
+    }
+
+    if (typeof this.filters.user_category !== 'undefined') {
+      params.user_category = this.filters.user_category;
     }
 
     return params;

--- a/src/resources/time-slot.test.ts
+++ b/src/resources/time-slot.test.ts
@@ -46,6 +46,14 @@ it('will set user filter using a number', async () => {
   });
 });
 
+it('will set user category filter using a number', async () => {
+  const resource = new TimeSlot(mockAxios);
+
+  expect(resource.withinUserCategory(1)).toHaveProperty('filters', {
+    user_category: 1,
+  });
+});
+
 it('will set users filter using a number', async () => {
   const resource = new TimeSlot(mockAxios);
 
@@ -137,7 +145,8 @@ it('can string all filterable options together', async () => {
       .excluding(1)
       .supporting(['en'])
       .visibility(Visibilities.ALL)
-      .withInviteOnly(),
+      .withInviteOnly()
+      .withinUserCategory(1),
   );
 
   expected.toHaveProperty('filters', {
@@ -150,6 +159,7 @@ it('can string all filterable options together', async () => {
     services: [1, 2],
     start: '2018-01-01',
     user: 1,
+    user_category: 1,
     users: [1, 2],
     visibility: Visibilities.ALL,
   });
@@ -211,6 +221,37 @@ it('can get time slots for a specified user', async () => {
       location_id: 1,
       service_id: [1, 2],
       staff_id: 1,
+      start: '2018-01-01',
+      supported_locales: ['en', 'es'],
+      timezone,
+      visibility: Visibilities.ALL,
+    },
+  });
+});
+
+it('can get time slots for a specified user category', async () => {
+  const resource = new TimeSlot(mockAxios);
+
+  const timezones = ['America/Chicago', 'America/Toronto', 'Europe/Amsterdam', 'Europe/Paris'];
+  const timezone = timezones[Math.floor(Math.random() * timezones.length)];
+
+  await resource
+    .between('2018-01-01', '2018-01-31')
+    .at(1)
+    .for([1, 2])
+    .supporting(['en', 'es'])
+    .withinUserCategory(1)
+    .in(timezone)
+    .visibility(Visibilities.ALL)
+    .get();
+
+  expect(mockAxios.get).toHaveBeenCalledTimes(1);
+  expect(mockAxios.get).toHaveBeenCalledWith('times', {
+    params: {
+      end: '2018-01-31',
+      location_id: 1,
+      service_id: [1, 2],
+      staff_category_id: 1,
       start: '2018-01-01',
       supported_locales: ['en', 'es'],
       timezone,

--- a/src/resources/time-slot.ts
+++ b/src/resources/time-slot.ts
@@ -14,6 +14,7 @@ export interface TimeSlotFilter {
   timezone?: string;
   locales?: string[];
   user?: number;
+  user_category?: number;
   users?: number | number[];
   visibility?: number;
 }
@@ -26,6 +27,7 @@ export interface TimeSlotParameters {
   location_id?: number;
   meeting_method?: number;
   service_id?: number | number[];
+  staff_category_id?: number;
   staff_id?: number;
   start?: string;
   supported_locales?: string[];
@@ -55,6 +57,8 @@ export interface TimeSlotResource extends Resource, ConditionalResource {
   visibility(visibility: number): this;
 
   withInviteOnly(inviteOnlyResources?: boolean): this;
+
+  withinUserCategory(userCategory: number | string): this;
 }
 
 export default class TimeSlot extends Conditional implements TimeSlotResource {
@@ -137,6 +141,10 @@ export default class TimeSlot extends Conditional implements TimeSlotResource {
       params.staff_id = this.filters.user;
     }
 
+    if (this.filters.user_category) {
+      params.staff_category_id = this.filters.user_category;
+    }
+
     if (this.filters.users) {
       params.additional_staff_id = this.filters.users;
     }
@@ -174,6 +182,12 @@ export default class TimeSlot extends Conditional implements TimeSlotResource {
 
   public withInviteOnly(inviteOnlyResources: boolean = true): this {
     this.filters.invite_only_resources = inviteOnlyResources;
+
+    return this;
+  }
+
+  public withinUserCategory(userCategory: number): this {
+    this.filters.user_category = userCategory;
 
     return this;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds user category filter to service, location, time slot and appointment resources.

## Motivation and context

We want an ability to filter services, locations and times by users within a category instead of a single user. We also need to be able specify user category when booking an appointment.

## How has this been tested?

Expanded existing and added new tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
