### PR TITLE
Add google filter for time-slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,10 @@ Set a filter which will tell the API to return time slots that are specifically 
 
 Send the API request using the pre-set filters.
 
+- `google(token: string)`
+
+Set a filter which will tell the API to return time slots that are not conflicting with events associated with the Google access token.
+
 - `in(timezone: string)`
 
 Set a filter which will tell the API to return time slots in the given timezone.
@@ -794,13 +798,14 @@ class TimeSlots {
     this.api = new OpenApi();
   }
 
-  async get({ appointment, end, location, service, start, user, userCategory, users }) {
+  async get({ appointment, end, location, service, start, token, user, userCategory, users }) {
     return await this.api
       .slots()
       .at(location)
       .attendedBy(users)
       .by(user)
       .for(service)
+      .google(token)
       .between(start, end)
       .excluding(appointment)
       .in('America/Chicago')

--- a/src/resources/time-slot.test.ts
+++ b/src/resources/time-slot.test.ts
@@ -131,6 +131,14 @@ it('will set a visibility filter', async () => {
   });
 });
 
+it('will set a google token filter', async () => {
+  const resource = new TimeSlot(mockAxios);
+
+  expect(resource.google('token')).toHaveProperty('filters', {
+    google: 'token',
+  });
+});
+
 it('can string all filterable options together', async () => {
   const resource = new TimeSlot(mockAxios);
 

--- a/src/resources/time-slot.ts
+++ b/src/resources/time-slot.ts
@@ -6,6 +6,7 @@ import Conditional, { ConditionalResource } from './conditional';
 export interface TimeSlotFilter {
   end?: string;
   exclusion?: number;
+  google?: string;
   invite_only_resources?: boolean,
   location?: number;
   method?: number;
@@ -23,6 +24,7 @@ export interface TimeSlotParameters {
   additional_staff_id?: number | number[];
   end?: string;
   exclusion?: number;
+  google?: string;
   invite_only_resources?: number,
   location_id?: number;
   meeting_method?: number;
@@ -47,6 +49,8 @@ export interface TimeSlotResource extends Resource, ConditionalResource {
   excluding(exclusion: number): this;
 
   for(services: number | number[]): this;
+
+  google(token: string): this;
 
   in(timezone: string): this;
 
@@ -121,6 +125,10 @@ export default class TimeSlot extends Conditional implements TimeSlotResource {
       params.exclusion = this.filters.exclusion;
     }
 
+    if (this.filters.google) {
+      params.google = this.filters.google;
+    }
+
     if (this.filters.invite_only_resources) {
       params.invite_only_resources = Number(this.filters.invite_only_resources);
     }
@@ -154,6 +162,12 @@ export default class TimeSlot extends Conditional implements TimeSlotResource {
     }
 
     return await this.client.get('times', { params });
+  }
+
+  public google(token: string): this {
+    this.filters.google = token;
+
+    return this;
   }
 
   public in(timezone: string): this {


### PR DESCRIPTION
## Description

This PR adds the `google` filter to time-slots. This filter uses the provided Google access token to only fetch time-slots that match the availability associated with the access token. 

## Motivation and context

This change is required to allow time-slots to be filtered using Google calendar events. The API uses the Google access token to fetch Google events, which are then used to check for conflicts.

## How has this been tested?

I have added a new test to the set of time-slots tests. It is focused on testing the new time-slot filter `google`. The test case is:
- will set a google token filter

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](https://travis-ci.org) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
