### PR TITLE
Added new uploads method to appointment API to allow file attachments to the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Set an attribute which will tell the API to use the given string as the term UTM
 
 Set an attribute which will tell the API to use the given origin constant as the booked through value when creating an appointment.
 
+- `uploads(uploadedFiles: UploadedFile[])`
+
+Attach uploaded files when creating an appointment.
+
 - `via(invitation: number)`
 
 Set an attribute which will tell the API to use the given invitation identifier when creating an appointment.
@@ -176,8 +180,9 @@ class Appointments {
 
   async add(attributes) {
     const {
-      address, appointment, campaign, city, content, country, email, firstName,
-      language, lastName, medium, notes, phone, question, source, term, value,
+      address, appointment, campaign, city, content, country, email, file,
+      firstName, key, language, lastName, medium, notes, phone, question,
+      source, term, value,
     } = attributes;
 
     const answer = (new Answer())
@@ -202,14 +207,17 @@ class Appointments {
       .term(term)
       .with(attendee)
       .through(Origins.MODERN_CLIENT_VIEW)
+      .uploads([{ key, file }])
       .notify(Notifications.ALL)
       .add(appointment);
   }
 
   async book(attributes) {
     const {
-      address, campaign, city, content, country, email, firstName, invitation, language, lastName,
-      location, locale, medium, notes, phone, question, service, source, start, term, timezone, user, userCategory, users, value, workflow,
+      address, campaign, city, content, country, email, file, firstName, key, 
+      invitation, language, lastName, location, locale, medium, notes, phone, 
+      question, service, source, start, term, timezone, user, userCategory, 
+      users, value, workflow,
     } = attributes;
 
     const answer = (new Answer())
@@ -238,6 +246,7 @@ class Appointments {
       .source(source)
       .supporting(locale)
       .term(term)
+      .uploads([{ key, file }])
       .via(invitation)
       .with(attendee)
       .through(Origins.MODERN_CLIENT_VIEW)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a new method named uploads that allows users the ability to attach file uploads to the appointment booking request as well as the attendee add. If uploads are added to the request, the content type will be switched from application/json to multipart/form-data. The data will be moved into its own part of the form data as json encoded string ready to be extracted and decoded for the backend. The uploads method takes in an array of the UploadedFile interface.

## Motivation and context

We have introduced a new upload question type that allows staff to create services with questions that allow clients to upload documents. Since the open api drives the client view, we will need to add the ability to upload files with the request.

A special note about the add method that allows users to add new clients to an existing appointment. Since it is a PUT, file uploads could not be extracted into the request on the backend. Using the method spoofing technique, I had to use a POST with the appointment attendee API and have it convert to PUT when it reached the backend.

## How has this been tested?

I have included two new tests and have relied on existing test to ensure current behaviour is still in tact.

1. The first test includes a file upload that converts the request payload that is sent. The test reviews the payload to ensure that the objects inside are correct.

2. The second test includes a file upload when adding a new attendee to an existing appointment. The test reviews the payload to ensure the objects inside are correct.

3. Existing tests are relied upon to ensure that existing behaviour remains functional. The tests do not include the uploads method and should behave as it did before this change I am making.

The goal was to make sure that if you don't use the uploads method, nothing changes and the current and expected behaviour remains the same. If you do use the uploads method, I tried to make sure the impact was minimal and that only the outgoing request payload will be adjusted.

## Screenshots (if appropriate)

n/a

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [  ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](https://travis-ci.org) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
