### PR TITLE
Hotfix/core 15245 add location category filter to service and time-slot resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,10 @@ Set a filter which will tell the API which resource the request comes from. Curr
 
 Set an attribute which will tell the API to allow services that are invite only or have invite only locations or users assigned to them.
 
+- `withinLocationCategory(locationCategory: number | string)`
+
+Set a filter which will tell the API to return users that are specifically for users within the location category matching the provided identifier.
+
 - `withinUserCategory(userCategory: number | string)`
 
 Set a filter which will tell the API to return services that are provided by user within the category matching the provided identifier.
@@ -701,7 +705,7 @@ class Services {
     this.api = new OpenApi();
   }
 
-  async get({ category, limit, location, method, page, region, resource, sortable, user, userCategory }) {
+  async get({ category, limit, location, locationCategory, method, page, region, resource, sortable, user, userCategory }) {
     return await this.api
       .services()
       .assigned()
@@ -713,6 +717,7 @@ class Services {
       .supporting(method)
       .through(resource)
       .withInviteOnly()
+      .withinLocationCategory(locationCategory)
       .withinUserCategory(userCategory)
       .on(page)
       .sortBy(sortable)
@@ -798,6 +803,10 @@ Set a filter which will tell the API whether to return time slots belonging to a
 
 Set an attribute which will tell the API to return time slots belonging to public and invite only resources.
 
+- `withinLocationCategory(locationCategory: number | string)`
+
+Set a filter which will tell the API to return users that are specifically for users within the location category matching the provided identifier.
+
 - `withinUserCategory(userCategory: number)`
 
 Set a filter which will tell the API to return time slots that are specifically for users within the category matching the provided identifier.
@@ -812,7 +821,7 @@ class TimeSlots {
     this.api = new OpenApi();
   }
 
-  async get({ appointment, end, location, service, start, token, user, userCategory, users }) {
+  async get({ appointment, end, location, locationCategory, service, start, token, user, userCategory, users }) {
     return await this.api
       .slots()
       .at(location)
@@ -826,6 +835,7 @@ class TimeSlots {
       .supporting(['en', 'fr', 'es'])
       .visibility(Visibilities.ALL)
       .withInviteOnly()
+      .withinLocationCategory(locationCategory)
       .withinUserCategory(userCategory)
       .get()
   }
@@ -902,7 +912,7 @@ class Users {
     this.api = new OpenApi();
   }
 
-  async get({ limit, location, method, page, region, resource, services, sortable }) {
+  async get({ limit, location, locationCategory, method, page, region, resource, services, sortable, userCategory }) {
     return await this.api
       .users()
       .assigned()
@@ -912,6 +922,8 @@ class Users {
       .supporting(method)
       .through(resource)
       .withInviteOnly()
+      .withinLocationCategory(locationCategory)
+      .withinUserCategory(userCategory)
       .on(page)
       .sortBy(sortable)
       .take(limit)

--- a/src/resources/service.test.ts
+++ b/src/resources/service.test.ts
@@ -51,6 +51,22 @@ it('will set location filter using a string', async () => {
   });
 });
 
+it('will set location category filter using a string', async () => {
+  const resource = new Service(mockAxios);
+
+  expect(resource.withinLocationCategory('identifier')).toHaveProperty('filters', {
+    location_category: 'identifier',
+  });
+});
+
+it('will set location category filter using a number', async () => {
+  const resource = new Service(mockAxios);
+
+  expect(resource.withinLocationCategory(1)).toHaveProperty('filters', {
+    location_category: 1,
+  });
+});
+
 it('will set the locatable filters as supplied', async () => {
   const resource = new Service(mockAxios);
   const region = 'SK';

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -19,6 +19,7 @@ export interface ServiceFilter {
   invitable?: number;
   invite_only_resources?: boolean,
   location?: number | string;
+  location_category?: number | string;
   method?: number;
   preferred?: number;
   resource?: string;
@@ -34,6 +35,7 @@ export interface ServiceParameters {
   invite_only?: number;
   invite_only_resources?: number,
   location?: number | string;
+  location_category?: number | string;
   preferred?: number;
   province?: string;
   resource?: string;
@@ -65,6 +67,8 @@ export interface ServiceResource extends Pageable, ConditionalResource {
   through(resource: string): this;
 
   withInviteOnly(inviteOnlyResources?: boolean): this;
+
+  withinLocationCategory(locationCategory: number | string): this;
 
   withinUserCategory(userCategory: number | string): this;
 }
@@ -203,6 +207,12 @@ export default class Service extends Conditional implements ServiceResource {
     return this;
   }
 
+  public withinLocationCategory(locationCategory: number | string): this {
+    this.filters.location_category = locationCategory;
+
+    return this;
+  }
+
   public withinUserCategory(userCategory: number | string): this {
     this.filters.user_category = userCategory;
 
@@ -254,6 +264,10 @@ export default class Service extends Conditional implements ServiceResource {
 
     if (typeof this.filters.user !== 'undefined') {
       params.user = this.filters.user;
+    }
+
+    if (typeof this.filters.location_category !== 'undefined') {
+      params.location_category = this.filters.location_category;
     }
 
     if (typeof this.filters.user_category !== 'undefined') {

--- a/src/resources/time-slot.test.ts
+++ b/src/resources/time-slot.test.ts
@@ -29,6 +29,22 @@ it('will set location filter using a number', async () => {
   });
 });
 
+it('will set location category filter using a number', async () => {
+  const resource = new TimeSlot(mockAxios);
+
+  expect(resource.withinLocationCategory(1)).toHaveProperty('filters', {
+    location_category: 1,
+  });
+});
+
+it('will set location category filter using a string', async () => {
+  const resource = new TimeSlot(mockAxios);
+
+  expect(resource.withinLocationCategory('identifier')).toHaveProperty('filters', {
+    location_category: 'identifier',
+  });
+});
+
 it('will set start and end filters', async () => {
   const resource = new TimeSlot(mockAxios);
 

--- a/src/resources/time-slot.ts
+++ b/src/resources/time-slot.ts
@@ -9,6 +9,7 @@ export interface TimeSlotFilter {
   google?: string;
   invite_only_resources?: boolean,
   location?: number;
+  location_category?: number | string;
   method?: number;
   services?: number | number[];
   start?: string;
@@ -27,6 +28,7 @@ export interface TimeSlotParameters {
   google?: string;
   invite_only_resources?: number,
   location_id?: number;
+  location_category_id?: number | string;
   meeting_method?: number;
   service_id?: number | number[];
   staff_category_id?: number;
@@ -61,6 +63,8 @@ export interface TimeSlotResource extends Resource, ConditionalResource {
   visibility(visibility: number): this;
 
   withInviteOnly(inviteOnlyResources?: boolean): this;
+
+  withinLocationCategory(locationCategory: number | string): this;
 
   withinUserCategory(userCategory: number | string): this;
 }
@@ -137,6 +141,10 @@ export default class TimeSlot extends Conditional implements TimeSlotResource {
       params.supported_locales = this.filters.locales;
     }
 
+    if (this.filters.location_category) {
+      params.location_category_id = this.filters.location_category;
+    }
+
     if (this.filters.method) {
       params.meeting_method = this.filters.method;
     }
@@ -196,6 +204,12 @@ export default class TimeSlot extends Conditional implements TimeSlotResource {
 
   public withInviteOnly(inviteOnlyResources: boolean = true): this {
     this.filters.invite_only_resources = inviteOnlyResources;
+
+    return this;
+  }
+
+  public withinLocationCategory(locationCategory: number | string): this {
+    this.filters.location_category = locationCategory;
 
     return this;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds location_category filter to service and time-slot resource.

## Motivation and context

Currently the location_category is not taken into account in filtering service and time-slots when provided through a booking shortcut.

## How has this been tested?

Added tests in the following files:

service.test.ts
time-slot.test.ts

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](https://travis-ci.org) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
