### PR TITLE
Adds support for external ID for queue appointment API

### DIFF
--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -3,6 +3,8 @@ import { AnswerModel } from './answer';
 import Model from './model';
 
 export interface ClientModel extends ModelInterface {
+  alias(alias: string | number): this;
+
   answers(answers: AnswerModel | AnswerModel[]): this;
 
   messagable(messageable: boolean): this;
@@ -24,6 +26,7 @@ export interface ClientAttributes {
 }
 
 export interface ClientParameters {
+  alias?: string | number;
   first_name: string | null;
   last_name: string | null;
   notes?: string;
@@ -51,6 +54,12 @@ export default class Client extends Model implements ClientModel {
       last_name: null,
       receive_sms: false,
     };
+  }
+
+  public alias(alias: string | number): this {
+    this.attributes.alias = alias;
+
+    return this;
   }
 
   public answers(answers: AnswerModel | AnswerModel[]): this {
@@ -112,6 +121,7 @@ export default class Client extends Model implements ClientModel {
     const attributes: object = {
       cell_phone: this.attributes.cell_phone,
       email: this.attributes.email,
+      external_id: this.attributes.alias,
       first_name: this.attributes.first_name,
       lang: this.attributes.lang,
       last_name: this.attributes.last_name,

--- a/src/resources/queue-appointment.test.ts
+++ b/src/resources/queue-appointment.test.ts
@@ -137,6 +137,7 @@ it('can book a queue appointment with the minimum required parameters', async ()
 it('can book a queue appointment with all available parameters', async () => {
   const resource = new QueueAppointment(mockAxios);
   const client = new Client()
+    .alias('EFG-456')
     .answers(new Answer().for(1).is('this answer'))
     .named('Jane', 'Doe')
     .messagable()
@@ -182,6 +183,7 @@ it('can book a queue appointment with all available parameters', async () => {
         client: {
           data: {
             attributes: {
+              external_id: 'EFG-456',
               first_name: 'Jane',
               last_name: 'Doe',
               cell_phone: '1-555-555-5555',


### PR DESCRIPTION
## Description

Adds an `alias` function to the Client model that is passed to the queue appointment API

## Motivation and context

Bring queue appointment API in line with appointments in terms of external ID support
https://bitbucket.org/coconutcalendar/coconut-calendar/pull-requests/10960

## How has this been tested?

Ran the automated tests locally, added to an existing case asserting that the queue appointment endpoint is hit with the external ID

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

