### PR TITLE
Update axios to version 0.31.1 to address (CVE-2026-40175) / (CVE-202…

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@types/uuid": "^3.4.5",
-    "axios": "~0.30.3",
+    "axios": "~0.31.1",
     "uuid": "^3.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@~0.30.3:
-  version "0.30.3"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.30.3.tgz#ab1be887a2d37dd9ebc219657704180faf2c4920"
-  integrity sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==
+axios@~0.31.1:
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.31.1.tgz#05b4c8f99e0b6f897708c74d6788d7535c6ac0c3"
+  integrity sha512-Ef8DUZSZQP6igY48mjGaoEjwhely97lserep0IFJifBH4YdKvwH5eMLniy3kig2HQoBNR8EkZpDjowxwTJcmbg==
   dependencies:
     follow-redirects "^1.15.4"
     form-data "^4.0.4"


### PR DESCRIPTION
## Description

This PR updates the `axios` dependency to `v0.31.1` to address ([CVE-2026-40175](https://nvd.nist.gov/vuln/detail/CVE-2026-40175)) and ([CVE-2025-62718](https://nvd.nist.gov/vuln/detail/CVE-2025-62718))

## Motivation

Identified by Jorge, the `axios` package must be updated to address potential vulnerabilities. This update contains breaking changes that do NOT affect this repo (only applies to Bower or direct git-tree installations). Read the release notes below:

- [v0.31.1 Release Notes ](https://github.com/axios/axios/releases/tag/v0.31.1)
- [v0.31.0 Release Notes](https://github.com/axios/axios/releases/tag/v0.31.0)

## How has this been tested?

Tests have been run, release notes have been read for breaking changes.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
