### PR TITLE
Update axios to version v0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@types/uuid": "^3.4.5",
-    "axios": "~0.31.1",
+    "axios": "~0.32.0",
     "uuid": "^3.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@~0.31.1:
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.31.1.tgz#05b4c8f99e0b6f897708c74d6788d7535c6ac0c3"
-  integrity sha512-Ef8DUZSZQP6igY48mjGaoEjwhely97lserep0IFJifBH4YdKvwH5eMLniy3kig2HQoBNR8EkZpDjowxwTJcmbg==
+axios@~0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.32.0.tgz#7859220c955272a72df8c0789ebd1219aba6d1d9"
+  integrity sha512-sGQArzERW2SI8IRkjuJ5y91Sm9QjiRq4Ay4kOLqpbBt5CeKDNq4g6nirJdyD+palK3yEDXnJiVXsesX66AjwyA==
   dependencies:
     follow-redirects "^1.15.4"
     form-data "^4.0.4"


### PR DESCRIPTION
## Description

This PR updates `axios` from `v0.31.1` to `v0.32.0`. This is required to address CVE-2026-44490.
`v0.32.0` **does** contain a breaking change, see [changelog](https://github.com/axios/axios/releases#:~:text=Compare-,v0.32.0,-v0.32.0%20%E2%80%94%20May%204):
> Null-prototype merged objects: mergeConfig and header merging now return objects with a null prototype to block prototype-pollution gadgets. Consumers must use Object.prototype.hasOwnProperty.call(obj, key) and avoid implicit string coercion against merged config or header objects. (https://github.com/axios/axios/pull/10838)

This is a non-issue for this repository, as `obj.hasOwnProperty` is never called, and `error.config`/`response.headers` is never manipulated. 

## How has this been tested?

1. Run `yarn test`
2. Review package changelog
3. Build package locally and booked an appointment via CV

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
